### PR TITLE
Fix typo in error msg of MAT_HDF5.jl/matopen

### DIFF
--- a/src/MAT_HDF5.jl
+++ b/src/MAT_HDF5.jl
@@ -83,7 +83,7 @@ end
 function matopen(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Bool, ff::Bool, compress::Bool)
     local f
     if ff && !wr
-        error("Cannot append to a write-only file")
+        error("Cannot append to a read-only file")
     end
     if !cr && !isfile(filename)
         error("File ", filename, " cannot be found")


### PR DESCRIPTION
Upon attempting to append to a read-only file, an error saying that it "cannot append to a write-only file" is returned. Presumably, the intended message was that appending to a READ-only file is not possible.